### PR TITLE
Merge to master branch which introduces new mutation and query (#15)

### DIFF
--- a/cmd/myblog/main.go
+++ b/cmd/myblog/main.go
@@ -92,12 +92,12 @@ func action(ctx *cli.Context) error {
 	}
 	db := client.Database("nomkhonwaan_com")
 
-	categoryRepo := blog.NewCategoryRepository(mongo.NewCustomCollection(db.Collection("categories")))
+	catRepo := blog.NewCategoryRepository(mongo.NewCustomCollection(db.Collection("categories")))
 	fileRepo := storage.NewFileRepository(mongo.NewCustomCollection(db.Collection("files")))
 	postRepo := blog.NewPostRepository(mongo.NewCustomCollection(db.Collection("posts")))
 	tagRepo := blog.NewTagRepository(mongo.NewCustomCollection(db.Collection("tags")))
 
-	service := blog.NewService(categoryRepo, postRepo, tagRepo)
+	service := blog.NewService(catRepo, postRepo, tagRepo)
 
 	schema := graphql.NewServer(service).Schema()
 	introspection.AddIntrospectionToSchema(schema)

--- a/pkg/blog/category.go
+++ b/pkg/blog/category.go
@@ -34,10 +34,10 @@ func (cat Category) MarshalJSON() ([]byte, error) {
 
 // CategoryRepository is a repository interface of category which defines all category entity related functions
 type CategoryRepository interface {
-	// Returns list of categories
+	// FindAll returns list of categories
 	FindAll(ctx context.Context) ([]Category, error)
 
-	// Returns list of categories from list of IDs
+	// FindAllByIDs returns list of categories from list of IDs
 	FindAllByIDs(ctx context.Context, ids interface{}) ([]Category, error)
 }
 

--- a/pkg/blog/category_test.go
+++ b/pkg/blog/category_test.go
@@ -31,13 +31,16 @@ func TestCategory_MarshalJSON(t *testing.T) {
 }
 
 func TestMongoCategoryRepository_FindAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		cur = mock_mongo.NewMockCursor(ctrl)
+		col = mock_mongo.NewMockCollection(ctrl)
+	)
+
 	t.Run("With successful finding all categories", func(t *testing.T) {
 		// Given
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		cur := mock_mongo.NewMockCursor(ctrl)
-		col := mock_mongo.NewMockCollection(ctrl)
 		ctx := context.Background()
 
 		col.EXPECT().Find(ctx, bson.D{}).Return(cur, nil)
@@ -53,15 +56,11 @@ func TestMongoCategoryRepository_FindAll(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("With an error has occurred while finding all categories", func(t *testing.T) {
+	t.Run("When an error has occurred while finding all categories", func(t *testing.T) {
 		// Given
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		col := mock_mongo.NewMockCollection(ctrl)
 		ctx := context.Background()
 
-		col.EXPECT().Find(ctx, bson.D{}).Return(nil, errors.New("something went wrong"))
+		col.EXPECT().Find(ctx, bson.D{}).Return(nil, errors.New("test find all categories error"))
 
 		repo := NewCategoryRepository(col)
 
@@ -69,18 +68,21 @@ func TestMongoCategoryRepository_FindAll(t *testing.T) {
 		_, err := repo.FindAll(ctx)
 
 		// Then
-		assert.EqualError(t, err, "something went wrong")
+		assert.EqualError(t, err, "test find all categories error")
 	})
 }
 
 func TestMongoCategoryRepository_FindAllByIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		cur = mock_mongo.NewMockCursor(ctrl)
+		col = mock_mongo.NewMockCollection(ctrl)
+	)
+
 	t.Run("With successful finding all categories by list of IDs", func(t *testing.T) {
 		// Given
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		cur := mock_mongo.NewMockCursor(ctrl)
-		col := mock_mongo.NewMockCollection(ctrl)
 		ctx := context.Background()
 		ids := []primitive.ObjectID{primitive.NewObjectID()}
 
@@ -103,10 +105,6 @@ func TestMongoCategoryRepository_FindAllByIDs(t *testing.T) {
 
 	t.Run("When unable to find all categories by list of IDs", func(t *testing.T) {
 		// Given
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		col := mock_mongo.NewMockCollection(ctrl)
 		ctx := context.Background()
 		ids := []primitive.ObjectID{primitive.NewObjectID()}
 

--- a/pkg/blog/mock/tag_mock.go
+++ b/pkg/blog/mock/tag_mock.go
@@ -34,6 +34,21 @@ func (m *MockTagRepository) EXPECT() *MockTagRepositoryMockRecorder {
 	return m.recorder
 }
 
+// FindAll mocks base method
+func (m *MockTagRepository) FindAll(arg0 context.Context) ([]blog.Tag, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindAll", arg0)
+	ret0, _ := ret[0].([]blog.Tag)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAll indicates an expected call of FindAll
+func (mr *MockTagRepositoryMockRecorder) FindAll(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockTagRepository)(nil).FindAll), arg0)
+}
+
 // FindAllByIDs mocks base method
 func (m *MockTagRepository) FindAllByIDs(arg0 context.Context, arg1 interface{}) ([]blog.Tag, error) {
 	m.ctrl.T.Helper()
@@ -47,4 +62,19 @@ func (m *MockTagRepository) FindAllByIDs(arg0 context.Context, arg1 interface{})
 func (mr *MockTagRepositoryMockRecorder) FindAllByIDs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllByIDs", reflect.TypeOf((*MockTagRepository)(nil).FindAllByIDs), arg0, arg1)
+}
+
+// FindByID mocks base method
+func (m *MockTagRepository) FindByID(arg0 context.Context, arg1 interface{}) (blog.Tag, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByID", arg0, arg1)
+	ret0, _ := ret[0].(blog.Tag)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID
+func (mr *MockTagRepositoryMockRecorder) FindByID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockTagRepository)(nil).FindByID), arg0, arg1)
 }

--- a/pkg/blog/post_test.go
+++ b/pkg/blog/post_test.go
@@ -226,8 +226,8 @@ func TestMongoPostRepository_FindByID(t *testing.T) {
 
 	singleResult := mock_mongo.NewMockSingleResult(ctrl)
 	col := mock_mongo.NewMockCollection(ctrl)
-	ctx := context.Background()
 
+	ctx := context.Background()
 	repo := NewPostRepository(col)
 
 	tests := map[string]struct {
@@ -239,7 +239,7 @@ func TestMongoPostRepository_FindByID(t *testing.T) {
 		},
 		"When an error has occurred while finding the result": {
 			id:  primitive.NewObjectID(),
-			err: errors.New("something went wrong"),
+			err: errors.New("test find by ID error"),
 		},
 	}
 
@@ -269,9 +269,10 @@ func TestMongoPostRepository_Save(t *testing.T) {
 
 	singleResult := mock_mongo.NewMockSingleResult(ctrl)
 	col := mock_mongo.NewMockCollection(ctrl)
-	ctx := context.Background()
 
+	ctx := context.Background()
 	repo := NewPostRepository(col)
+	tagID := primitive.NewObjectID()
 
 	tests := map[string]struct {
 		q      PostQuery
@@ -284,15 +285,20 @@ func TestMongoPostRepository_Save(t *testing.T) {
 			id:     primitive.NewObjectID(),
 			update: bson.M{"$set": bson.M{}},
 		},
-		"With updated title": {
+		"When updating post's title": {
 			q:      NewPostQueryBuilder().WithTitle("Test update post title").Build(),
 			id:     primitive.NewObjectID(),
 			update: bson.M{"$set": bson.M{"title": "Test update post title"}},
 		},
-		"With updated post content": {
+		"When updating post's content": {
 			q:      NewPostQueryBuilder().WithMarkdown("Test update post content").WithHTML("<p>Test update post content</p>").Build(),
 			id:     primitive.NewObjectID(),
 			update: bson.M{"$set": bson.M{"markdown": "Test update post content", "html": "<p>Test update post content</p>"}},
+		},
+		"When updating post's tags": {
+			q:      NewPostQueryBuilder().WithTags([]Tag{{ID: tagID, Name: "Blog", Slug: "blog-" + tagID.Hex()}}).Build(),
+			id:     primitive.NewObjectID(),
+			update: bson.M{"$set": bson.M{"tags": bson.A{mongo.DBRef{Ref: "tags", ID: tagID}}}},
 		},
 		"When an error has occurred while updating the post": {
 			q:      NewPostQueryBuilder().Build(),

--- a/pkg/blog/tag_test.go
+++ b/pkg/blog/tag_test.go
@@ -30,14 +30,59 @@ func TestTag_MarshalJSON(t *testing.T) {
 	assert.Equal(t, "{\"id\":\""+id.Hex()+"\",\"name\":\"Golang\",\"slug\":\"golang-"+id.Hex()+"\"}", string(result))
 }
 
+func TestMongoTagRepository_FindAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		cur = mock_mongo.NewMockCursor(ctrl)
+		col = mock_mongo.NewMockCollection(ctrl)
+	)
+
+	t.Run("With successful finding all tags", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+
+		col.EXPECT().Find(ctx, bson.D{}).Return(cur, nil)
+		cur.EXPECT().Close(ctx).Return(nil)
+		cur.EXPECT().Decode(gomock.Any()).Return(nil)
+
+		repo := NewTagRepository(col)
+
+		// When
+		_, err := repo.FindAll(ctx)
+
+		// Then
+		assert.Nil(t, err)
+	})
+
+	t.Run("When an error has occurred while finding all tags", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+
+		col.EXPECT().Find(ctx, bson.D{}).Return(nil, errors.New("test find all tags error"))
+
+		repo := NewTagRepository(col)
+
+		// When
+		_, err := repo.FindAll(ctx)
+
+		// Then
+		assert.EqualError(t, err, "test find all tags error")
+	})
+}
+
 func TestMongoTagRepository_FindAllByIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		cur = mock_mongo.NewMockCursor(ctrl)
+		col = mock_mongo.NewMockCollection(ctrl)
+	)
+
 	t.Run("With successful finding all tags by list of IDs", func(t *testing.T) {
 		// Given
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		cur := mock_mongo.NewMockCursor(ctrl)
-		col := mock_mongo.NewMockCollection(ctrl)
 		ctx := context.Background()
 		ids := []primitive.ObjectID{primitive.NewObjectID()}
 
@@ -60,10 +105,6 @@ func TestMongoTagRepository_FindAllByIDs(t *testing.T) {
 
 	t.Run("When unable to find all tags by list of IDs", func(t *testing.T) {
 		// Given
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		col := mock_mongo.NewMockCollection(ctrl)
 		ctx := context.Background()
 		ids := []primitive.ObjectID{primitive.NewObjectID()}
 
@@ -77,4 +118,47 @@ func TestMongoTagRepository_FindAllByIDs(t *testing.T) {
 		// Then
 		assert.EqualError(t, err, "test unable to find all tags by list of IDs")
 	})
+}
+
+func TestMongoTagRepository_FindByID(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	singleResult := mock_mongo.NewMockSingleResult(ctrl)
+	col := mock_mongo.NewMockCollection(ctrl)
+
+	ctx := context.Background()
+	repo := NewTagRepository(col)
+
+	tests := map[string]struct {
+		id  interface{}
+		err error
+	}{
+		"With existing tag ID": {
+			id: primitive.NewObjectID(),
+		},
+		"When an error has occurred while finding the result": {
+			id:  primitive.NewObjectID(),
+			err: errors.New("test find by ID error"),
+		},
+	}
+
+	// When
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			col.EXPECT().FindOne(ctx, bson.M{"_id": test.id.(primitive.ObjectID)}, gomock.Any()).Return(singleResult)
+			singleResult.EXPECT().Decode(gomock.Any()).Return(test.err)
+
+			if test.err == nil {
+				_, err := repo.FindByID(ctx, test.id)
+				assert.Nil(t, err)
+			} else {
+				_, err := repo.FindByID(ctx, test.id)
+				assert.EqualError(t, err, test.err.Error())
+			}
+		})
+	}
+
+	// Then
 }

--- a/pkg/graphql/handler_test.go
+++ b/pkg/graphql/handler_test.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/golang/mock/gomock"
+	"github.com/nomkhonwaan/myblog/pkg/auth"
 	"github.com/nomkhonwaan/myblog/pkg/blog"
 	mock_blog "github.com/nomkhonwaan/myblog/pkg/blog/mock"
 	. "github.com/nomkhonwaan/myblog/pkg/graphql"
 	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -28,12 +32,20 @@ func TestHandler(t *testing.T) {
 		catRepo  = mock_blog.NewMockCategoryRepository(ctrl)
 		postRepo = mock_blog.NewMockPostRepository(ctrl)
 		tagRepo  = mock_blog.NewMockTagRepository(ctrl)
-
-		newGraphQLRequest = func(q query) *http.Request {
-			v, _ := json.Marshal(q)
-			return httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewReader(v))
-		}
 	)
+
+	newGraphQLRequest := func(q query) *http.Request {
+		v, _ := json.Marshal(q)
+		return httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewReader(v))
+	}
+
+	withAuthorizedID := func(r *http.Request) *http.Request {
+		return r.WithContext(context.WithValue(context.Background(), auth.UserProperty, &jwt.Token{
+			Claims: jwt.MapClaims{
+				"sub": "authorizedID",
+			},
+		}))
+	}
 
 	service.EXPECT().Category().Return(catRepo).AnyTimes()
 	service.EXPECT().Post().Return(postRepo).AnyTimes()
@@ -76,5 +88,106 @@ func TestHandler(t *testing.T) {
 
 		// Then
 		assert.Equal(t, "200 OK", w.Result().Status)
+	})
+
+	t.Run("Find post by its ID", func(t *testing.T) {
+		t.Run("With existing published post", func(t *testing.T) {
+			// Given
+			expected := primitive.NewObjectID()
+			slug := "test-published-" + expected.Hex()
+			q := query{Query: `{ post(slug: "` + slug + `") { slug } }`}
+
+			w := httptest.NewRecorder()
+
+			postRepo.EXPECT().FindByID(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, id interface{}) (blog.Post, error) {
+				assert.IsType(t, primitive.ObjectID{}, id)
+				assert.Equal(t, expected.Hex(), id.(primitive.ObjectID).Hex())
+
+				return blog.Post{Status: blog.Published}, nil
+			})
+
+			// When
+			h.ServeHTTP(w, newGraphQLRequest(q))
+
+			// Then
+			assert.Equal(t, "200 OK", w.Result().Status)
+		})
+
+		t.Run("With existing draft post", func(t *testing.T) {
+			// Given
+			expected := primitive.NewObjectID()
+			slug := "test-draft-" + expected.Hex()
+			q := query{Query: `{ post(slug: "` + slug + `") { slug } }`}
+
+			w := httptest.NewRecorder()
+
+			postRepo.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(blog.Post{Status: blog.Draft, AuthorID: "authorizedID"}, nil)
+
+			// When
+			h.ServeHTTP(w, withAuthorizedID(newGraphQLRequest(q)))
+
+			// Then
+			assert.Equal(t, "200 OK", w.Result().Status)
+		})
+
+		t.Run("When an error has occurred while querying post", func(t *testing.T) {
+			// Given
+			expected := primitive.NewObjectID()
+			slug := "test-published-" + expected.Hex()
+			q := query{Query: `{ post(slug: "` + slug + `") { slug } }`}
+
+			w := httptest.NewRecorder()
+
+			postRepo.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(blog.Post{}, errors.New("test error on finding post by ID"))
+
+			// When
+			h.ServeHTTP(w, newGraphQLRequest(q))
+
+			// Then
+			var result map[string]interface{}
+			_ = json.NewDecoder(w.Body).Decode(&result)
+
+			assert.Equal(t, "post: test error on finding post by ID", result["errors"].([]interface{})[0].(string))
+		})
+
+		t.Run("With existing draft post but unable to retrieve authorized ID", func(t *testing.T) {
+			// Given
+			expected := primitive.NewObjectID()
+			slug := "test-draft-" + expected.Hex()
+			q := query{Query: `{ post(slug: "` + slug + `") { slug } }`}
+
+			w := httptest.NewRecorder()
+
+			postRepo.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(blog.Post{Status: blog.Draft}, nil)
+
+			// When
+			h.ServeHTTP(w, newGraphQLRequest(q))
+
+			// Then
+			var result map[string]interface{}
+			_ = json.NewDecoder(w.Body).Decode(&result)
+
+			assert.Equal(t, "post: Unauthorized", result["errors"].([]interface{})[0].(string))
+		})
+
+		t.Run("With existing draft post but not post's author", func(t *testing.T) {
+			// Given
+			expected := primitive.NewObjectID()
+			slug := "test-draft-" + expected.Hex()
+			q := query{Query: `{ post(slug: "` + slug + `") { slug } }`}
+
+			w := httptest.NewRecorder()
+
+			postRepo.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(blog.Post{Status: blog.Draft, AuthorID: "otherAuthorizedID"}, nil)
+
+			// When
+			h.ServeHTTP(w, withAuthorizedID(newGraphQLRequest(q)))
+
+			// Then
+			var result map[string]interface{}
+			_ = json.NewDecoder(w.Body).Decode(&result)
+
+			assert.Equal(t, "post: Forbidden", result["errors"].([]interface{})[0].(string))
+		})
 	})
 }

--- a/pkg/graphql/handler_test.go
+++ b/pkg/graphql/handler_test.go
@@ -69,6 +69,21 @@ func TestHandler(t *testing.T) {
 		assert.Equal(t, "200 OK", w.Result().Status)
 	})
 
+	t.Run("With successful querying list of tags", func(t *testing.T) {
+		// Given
+		q := query{Query: `{ tags { slug } }`}
+
+		w := httptest.NewRecorder()
+
+		tagRepo.EXPECT().FindAll(gomock.Any()).Return([]blog.Tag{}, nil)
+
+		// When
+		h.ServeHTTP(w, newGraphQLRequest(q))
+
+		// Then
+		assert.Equal(t, "200 OK", w.Result().Status)
+	})
+
 	t.Run("With successful querying the latest published posts", func(t *testing.T) {
 		// Given
 		q := query{Query: `{ latestPublishedPosts(offset: 0, limit: 5) { slug } }`}

--- a/pkg/graphql/handler_test.go
+++ b/pkg/graphql/handler_test.go
@@ -1,0 +1,80 @@
+package graphql_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/golang/mock/gomock"
+	"github.com/nomkhonwaan/myblog/pkg/blog"
+	mock_blog "github.com/nomkhonwaan/myblog/pkg/blog/mock"
+	. "github.com/nomkhonwaan/myblog/pkg/graphql"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type query struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+func TestHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		service  = mock_blog.NewMockService(ctrl)
+		catRepo  = mock_blog.NewMockCategoryRepository(ctrl)
+		postRepo = mock_blog.NewMockPostRepository(ctrl)
+		tagRepo  = mock_blog.NewMockTagRepository(ctrl)
+
+		newGraphQLRequest = func(q query) *http.Request {
+			v, _ := json.Marshal(q)
+			return httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewReader(v))
+		}
+	)
+
+	service.EXPECT().Category().Return(catRepo).AnyTimes()
+	service.EXPECT().Post().Return(postRepo).AnyTimes()
+	service.EXPECT().Tag().Return(tagRepo).AnyTimes()
+
+	server := NewServer(service)
+	h := Handler(server.Schema())
+
+	t.Run("With successful querying list of categories", func(t *testing.T) {
+		// Given
+		q := query{Query: `{ categories { slug } }`}
+
+		w := httptest.NewRecorder()
+
+		catRepo.EXPECT().FindAll(gomock.Any()).Return([]blog.Category{}, nil)
+
+		// When
+		h.ServeHTTP(w, newGraphQLRequest(q))
+
+		// Then
+		assert.Equal(t, "200 OK", w.Result().Status)
+	})
+
+	t.Run("With successful querying the latest published posts", func(t *testing.T) {
+		// Given
+		q := query{Query: `{ latestPublishedPosts(offset: 0, limit: 5) { slug } }`}
+
+		w := httptest.NewRecorder()
+
+		postRepo.EXPECT().FindAll(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, q blog.PostQuery) ([]blog.Post, error) {
+			assert.Equal(t, blog.Published, q.Status())
+			assert.EqualValues(t, 0, q.Offset())
+			assert.EqualValues(t, 5, q.Limit())
+
+			return make([]blog.Post, 0), nil
+		})
+
+		// When
+		h.ServeHTTP(w, newGraphQLRequest(q))
+
+		// Then
+		assert.Equal(t, "200 OK", w.Result().Status)
+	})
+}

--- a/pkg/graphql/server.go
+++ b/pkg/graphql/server.go
@@ -96,7 +96,6 @@ func (s *Server) makeFieldFuncPost(ctx context.Context, args struct {
 		return blog.Post{}, err
 	}
 
-	// do not check authority if the post had published
 	if p.Status == blog.Published {
 		return p, nil
 	}
@@ -146,7 +145,6 @@ func (s *Server) makeFieldFuncUpdatePostContent(ctx context.Context, args struct
 	if err != nil {
 		return blog.Post{}, err
 	}
-
 	html := blackfriday.Run([]byte(args.Markdown))
 
 	return s.service.Post().Save(ctx, id, blog.NewPostQueryBuilder().WithMarkdown(args.Markdown).WithHTML(string(html)).Build())

--- a/pkg/graphql/server.go
+++ b/pkg/graphql/server.go
@@ -59,6 +59,7 @@ func (s *Server) registerQuery(schema *schemabuilder.Schema) {
 	obj := schema.Query()
 
 	obj.FieldFunc("categories", s.makeFieldFuncCategories)
+	obj.FieldFunc("tags", s.makeFieldFuncTags)
 	obj.FieldFunc("latestPublishedPosts", s.makeFieldFuncLatestPublishedPosts)
 	obj.FieldFunc("post", s.makeFieldFuncPost)
 }
@@ -69,6 +70,7 @@ func (s *Server) registerMutation(schema *schemabuilder.Schema) {
 	obj.FieldFunc("createPost", s.makeFieldFuncCreatePost)
 	obj.FieldFunc("updatePostTitle", s.makeFieldFuncUpdatePostTitle)
 	obj.FieldFunc("updatePostContent", s.makeFieldFuncUpdatePostContent)
+	obj.FieldFunc("updatePostTags", s.makeFieldFuncUpdatePostTags)
 }
 
 func (s *Server) registerPost(schema *schemabuilder.Schema) {
@@ -80,6 +82,10 @@ func (s *Server) registerPost(schema *schemabuilder.Schema) {
 
 func (s *Server) makeFieldFuncCategories(ctx context.Context) ([]blog.Category, error) {
 	return s.service.Category().FindAll(ctx)
+}
+
+func (s *Server) makeFieldFuncTags(ctx context.Context) ([]blog.Tag, error) {
+	return s.service.Tag().FindAll(ctx)
 }
 
 func (s *Server) makeFieldFuncLatestPublishedPosts(ctx context.Context, args struct{ Offset, Limit int64 }) ([]blog.Post, error) {
@@ -148,6 +154,30 @@ func (s *Server) makeFieldFuncUpdatePostContent(ctx context.Context, args struct
 	html := blackfriday.Run([]byte(args.Markdown))
 
 	return s.service.Post().Save(ctx, id, blog.NewPostQueryBuilder().WithMarkdown(args.Markdown).WithHTML(string(html)).Build())
+}
+
+func (s *Server) makeFieldFuncUpdatePostTags(ctx context.Context, args struct {
+	Slug     Slug   `graphql:"slug"`
+	TagSlugs []Slug `graphql:"tagSlugs"`
+}) (blog.Post, error) {
+	id := args.Slug.MustGetID()
+
+	err := s.validateAuthority(ctx, id)
+	if err != nil {
+		return blog.Post{}, err
+	}
+
+	var ids []primitive.ObjectID
+	for _, slug := range args.TagSlugs {
+		ids = append(ids, slug.MustGetID().(primitive.ObjectID))
+	}
+
+	tags, err := s.service.Tag().FindAllByIDs(ctx, ids)
+	if err != nil {
+		return blog.Post{}, err
+	}
+
+	return s.service.Post().Save(ctx, id, blog.NewPostQueryBuilder().WithTags(tags).Build())
 }
 
 // getAuthorizedUserID returns an authorized user ID (which generated from the authentication server),

--- a/pkg/graphql/server_test.go
+++ b/pkg/graphql/server_test.go
@@ -1,0 +1,47 @@
+package graphql_test
+
+import (
+	. "github.com/nomkhonwaan/myblog/pkg/graphql"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"testing"
+)
+
+func TestSlug_GetID(t *testing.T) {
+	// Given
+	id := primitive.NewObjectID()
+	slug := Slug(id.Hex())
+
+	// When
+	result, err := slug.GetID()
+
+	// Then
+	assert.Nil(t, err)
+	assert.Equal(t, id, result)
+}
+
+func TestSlug_MustGetID(t *testing.T) {
+	t.Run("With valid ObjectID string", func(t *testing.T) {
+		// Given
+		id := primitive.NewObjectID()
+		slug := Slug(id.Hex())
+
+		// When
+		result := slug.MustGetID()
+
+		// Then
+		assert.Equal(t, id, result)
+	})
+
+	t.Run("With invalid ObjectID string", func(t *testing.T) {
+		// Given
+		slug := Slug("invalid-object-id")
+
+		// When
+		result := slug.MustGetID()
+
+		// Then
+		assert.IsType(t, primitive.ObjectID{}, result)
+		assert.NotEmpty(t, result.(primitive.ObjectID).Hex())
+	})
+}


### PR DESCRIPTION
This PR have...

- A new query for retrieving the list of tags `{ tags {...} }`
- A new mutation for updating post's tags by sending post's slug and list of tag's slug
  ```
    mutation {
      updatePostTags(slug: string!, tagSlugs: [string!]!) {
        /* post fragment */
      }
    }
  ```

which closes #13