### PR TITLE
Fix unable to find time zone data on scratch image

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:1.13-alpine AS builder
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/nomkhonwaan/myblog
-RUN apk add -u --no-cache ca-certificates curl git make
+RUN apk add -u --no-cache ca-certificates curl git make tzdata
 COPY go.mod go.sum Makefile ./
 RUN make install
 COPY . .
 RUN make build
 FROM scratch
-VOLUME ./.cache
 COPY --from=builder /etc/ssl/certs/* /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/nomkhonwaan/myblog/bin/myblog .
+COPY --from=builder /usr/share/zoneinfo/* /usr/share/zoneinfo/
 ENTRYPOINT ["/myblog"]

--- a/build/package/Dockerfile.all-in-one
+++ b/build/package/Dockerfile.all-in-one
@@ -2,7 +2,7 @@ ARG NPM_AUTH_TOKEN
 FROM golang:1.13-alpine AS builder
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/nomkhonwaan/myblog
-RUN apk add -u --no-cache ca-certificates curl git make
+RUN apk add -u --no-cache ca-certificates curl git make tzdata
 COPY go.mod go.sum Makefile ./
 RUN make install
 COPY . .
@@ -18,8 +18,8 @@ RUN make install-web && \
 COPY . .
 RUN make build-web
 FROM scratch
-VOLUME ./.cache
 COPY --from=builder /etc/ssl/certs/* /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/nomkhonwaan/myblog/bin/myblog .
+COPY --from=builder /usr/share/zoneinfo/* /usr/share/zoneinfo/
 COPY --from=web-builder /opt/app-root/web/dist/ ./dist/
 ENTRYPOINT ["/myblog"]

--- a/pkg/facebook/facebook.go
+++ b/pkg/facebook/facebook.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	bangkokTimeZone, _ = time.LoadLocation("Asia/Bangkok")
+	// DefaultTimeZone uses to format date-time in the specific time zone, default is Asia/Bangkok which is GMT + 7
+	DefaultTimeZone, _ = time.LoadLocation("Asia/Bangkok")
 )
 
 // IsFacebookCrawlerRequest does checking the request user-agent strings.
@@ -120,7 +121,7 @@ func (mw CrawlerMiddleware) serveSingle(w http.ResponseWriter, r *http.Request, 
 		Description   string
 		FeaturedImage string
 	}{
-		URL:           "https://beta.nomkhonwaan.com/" + p.PublishedAt.In(bangkokTimeZone).Format("2006/1/2") + "/" + p.Slug,
+		URL:           "https://beta.nomkhonwaan.com/" + p.PublishedAt.In(DefaultTimeZone).Format("2006/1/2") + "/" + p.Slug,
 		Type:          "article",
 		Title:         p.Title,
 		Description:   strings.Split(p.Markdown, "\n")[0],

--- a/pkg/facebook/facebook_test.go
+++ b/pkg/facebook/facebook_test.go
@@ -130,7 +130,7 @@ func TestCrawlerMiddleware_Handler(t *testing.T) {
 		// Given
 		id := primitive.NewObjectID()
 		featuredImageID := primitive.NewObjectID()
-		now := time.Now()
+		now := time.Now().In(DefaultTimeZone)
 		post := blog.Post{
 			ID:            id,
 			Title:         "Test post",


### PR DESCRIPTION
This PR has...

- Add time zone data (from Alpine image) to the Docker's scratch image
- Fix empty cache file written due to multiple consume on `io.Reader`