### PR TITLE
Auto-save on keypress event

### DIFF
--- a/web/src/app/admin/editor/editor.component.ts
+++ b/web/src/app/admin/editor/editor.component.ts
@@ -83,7 +83,15 @@ export class EditorComponent implements OnInit {
   }
 
   onChangingSuccess(post: Post): void {
-    this.post = post;
+    this.post.slug = post.slug;
+    this.post.status = post.status;
+    this.post.html = post.html;
+    this.post.publishedAt = post.publishedAt;
+    this.post.categories = post.categories;
+    this.post.tags = post.tags;
+    this.post.featuredImage = post.featuredImage;
+    this.post.attachments = post.attachments;
+    this.post.updatedAt = post.updatedAt;
 
     this.title.setTitle(`Edit · ${post.title} - ${environment.title}`);
   }

--- a/web/src/app/admin/editor/height-as-scroll.directive.ts
+++ b/web/src/app/admin/editor/height-as-scroll.directive.ts
@@ -3,6 +3,11 @@ import { AfterViewInit, Directive, ElementRef, HostListener } from '@angular/cor
 @Directive({ selector: '[appHeightAsScroll]' })
 export class HeightAsScrollDirective implements AfterViewInit {
 
+  /**
+   * Store a previous scroll height for comparing when keypress but still in the same line
+   */
+  private previousScrollHeight: number;
+
   constructor(private host: ElementRef) { }
 
   ngAfterViewInit(): void {
@@ -22,7 +27,11 @@ export class HeightAsScrollDirective implements AfterViewInit {
   private resize(): void {
     const elem: HTMLElement = this.host.nativeElement as HTMLElement;
 
-    elem.style.height = elem.scrollHeight.toString() + 'px';
+    if (elem.scrollHeight !== this.previousScrollHeight) {
+      elem.style.height = elem.scrollHeight.toString() + 'px';
+    }
+
+    this.previousScrollHeight = elem.scrollHeight;
   }
 
 }

--- a/web/src/app/admin/editor/markdown/markdown.component.html
+++ b/web/src/app/admin/editor/markdown/markdown.component.html
@@ -1,1 +1,2 @@
-<textarea appHeightAsScroll class="input -textarea" placeholder="Markdown" (change)="onChange()" [(ngModel)]="post.markdown"></textarea>
+<textarea appHeightAsScroll class="input -textarea" placeholder="Markdown" (change)="onChange()"
+  (keypress)="onKeyPress()" [(ngModel)]="post.markdown"></textarea>

--- a/web/src/app/admin/editor/markdown/markdown.component.ts
+++ b/web/src/app/admin/editor/markdown/markdown.component.ts
@@ -1,14 +1,37 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { AbstractPostEditorComponent } from '../abstract-post-editor.component';
+import { BehaviorSubject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 
 @Component({
   selector: 'app-post-markdown-editor',
   templateUrl: './markdown.component.html',
   styleUrls: ['./markdown.component.scss'],
 })
-export class PostMarkdownEditorComponent extends AbstractPostEditorComponent {
+export class PostMarkdownEditorComponent extends AbstractPostEditorComponent implements OnInit {
+
+  /**
+   * Use for debouncing keypress event on markdown value
+   */
+  markdown$: BehaviorSubject<string> = new BehaviorSubject('');
+
+  ngOnInit(): void {
+    this.markdown$.next(this.post.markdown);
+
+    this.markdown$.pipe(debounceTime(1600)).subscribe((markdown: string): void => {
+      this.updatePostContent(this.post.slug, markdown);
+    });
+  }
 
   onChange(): void {
+    this.updatePostContent(this.post.slug, this.post.markdown);
+  }
+
+  onKeyPress(): void {
+    this.markdown$.next(this.post.markdown);
+  }
+
+  private updatePostContent(slug: string, markdown: string): void {
     this.mutate(
       `
         mutation {
@@ -18,10 +41,9 @@ export class PostMarkdownEditorComponent extends AbstractPostEditorComponent {
         }
       `,
       {
-        slug: this.post.slug,
-        markdown: this.post.markdown,
+        slug,
+        markdown,
       }
     );
   }
-
 }


### PR DESCRIPTION
This PR has...

- Enable auto-saving function on markdown editor when keypress event invoked
- Fix invalid resizing on markdown editor even no newline
- Improve post updating function by not replace an entire post object